### PR TITLE
Added Podspec

### DIFF
--- a/JYGraphView.podspec
+++ b/JYGraphView.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |spec|
+  spec.name         = 'JYGraphView'
+  spec.version      = '0.1.0'
+  spec.license      = { :type => 'MIT' }
+  spec.homepage     = 'https://github.com/johnyorke/JYGraphView'
+  spec.authors      = { 'John Yorke' => 'hello@johnyorke.me' }
+  spec.summary      = 'Simple line graph view for iOS.'
+  spec.source       = { :git => 'https://github.com/johnyorke/JYGraphView', :tag => spec.version }
+  spec.source_files = 'JYGraphViewDemoProject/JYGraphViewDemoProject/{JYGraphView,JYGraphPoint}.{h,m}'
+  spec.platform     = :ios, '6.0'
+  spec.requires_arc = true
+end


### PR DESCRIPTION
Addresses issue #4. This adds a Podspec that can be published to the Cocoapods repository. It will require a git tag with the name "0.1.0" (or whatever version number you choose) to be published.