### PR TITLE
Support customizing X axis labels

### DIFF
--- a/JYGraphViewDemoProject/JYGraphViewDemoProject/JYGraphView.h
+++ b/JYGraphViewDemoProject/JYGraphViewDemoProject/JYGraphView.h
@@ -56,6 +56,12 @@
 // Font colour of the x and y axis labels
 @property (strong, nonatomic) UIColor *labelFontColor;
 
+// Font to use only on the x axis labels
+@property (strong, nonatomic) UIFont *labelXFont;
+
+// Font colour only on the x axis labels
+@property (strong, nonatomic) UIColor *labelXFontColor;
+
 // Colour of the background for the x and y axis UILabels
 @property (strong, nonatomic) UIColor *labelBackgroundColor;
 

--- a/JYGraphViewDemoProject/JYGraphViewDemoProject/JYGraphView.m
+++ b/JYGraphViewDemoProject/JYGraphViewDemoProject/JYGraphView.m
@@ -66,6 +66,12 @@ NSInteger const kPointLabelHeight = 20;
     if (!self.labelFontColor) {
         self.labelFontColor = [UIColor whiteColor];
     }
+    if (!self.labelXFont) {
+        self.labelXFont = self.labelFont;
+    }
+    if (!self.labelXFontColor) {
+        self.labelXFontColor = self.labelFontColor;
+    }
     if (!self.labelBackgroundColor) {
         self.labelBackgroundColor = [UIColor colorWithRed:0.1f green:0.1f blue:0.1f alpha:0.5f];
     }
@@ -205,11 +211,11 @@ NSInteger const kPointLabelHeight = 20;
     
     label.textAlignment = NSTextAlignmentCenter;
     
-    [label setTextColor:self.labelFontColor];
+    [label setTextColor:self.labelXFontColor];
     [label setBackgroundColor:self.barColor];
     [label setAdjustsFontSizeToFitWidth:YES];
     [label setMinimumScaleFactor:0.6];
-    [label setFont:self.labelFont];
+    [label setFont:self.labelXFont];
     [label setNumberOfLines:2];
     
     if (self.graphDataLabels) {


### PR DESCRIPTION
For some small views, it's nice to make an X axis labels a bit different than the point labels.
This is a way I suggest doing it in this pull request.

``` obj-c
graphView.labelFont = [UIFont systemFontOfSize:18];
graphView.labelXFont = [UIFont systemFontOfSize:16];
graphView.labelXFontColor = [UIColor lightGrayColor];
```

Tested on AppleWatch Simulator.
